### PR TITLE
🚀 [Feature]: Standardize casing for 'Ast'

### DIFF
--- a/src/functions/public/Core/Get-ASTCommand.ps1
+++ b/src/functions/public/Core/Get-ASTCommand.ps1
@@ -1,12 +1,12 @@
 ﻿function Get-AstCommand {
     <#
         .SYNOPSIS
-        Retrieves command AST (Abstract Syntax Tree) elements from a PowerShell script or AST object.
+        Retrieves command Ast (Abstract Syntax Tree) elements from a PowerShell script or Ast object.
 
         .DESCRIPTION
-        This function extracts and returns command AST elements from a specified PowerShell script file,
-        script content, or an existing AST object. The function supports multiple input methods, including
-        direct script text, file paths, or existing AST objects. It also provides an option to search nested
+        This function extracts and returns command Ast elements from a specified PowerShell script file,
+        script content, or an existing Ast object. The function supports multiple input methods, including
+        direct script text, file paths, or existing Ast objects. It also provides an option to search nested
         functions and script block expressions.
 
         .EXAMPLE
@@ -19,7 +19,7 @@
         Errors : {}
         ```
 
-        Parses the specified script file and extracts command AST elements.
+        Parses the specified script file and extracts command Ast elements.
 
         .EXAMPLE
         Get-AstCommand -Script "Get-Process; Write-Host 'Hello'"
@@ -31,7 +31,7 @@
         Errors : {}
         ```
 
-        Parses the provided script content and extracts command AST elements.
+        Parses the provided script content and extracts command Ast elements.
 
         .EXAMPLE
         $ast = [System.Management.Automation.Language.Parser]::ParseInput("Get-Process", [ref]$null, [ref]$null)
@@ -44,13 +44,13 @@
         Errors : {}
         ```
 
-        Extracts command AST elements from a manually parsed AST object.
+        Extracts command Ast elements from a manually parsed Ast object.
 
         .OUTPUTS
         PSCustomObject
 
         .NOTES
-        Returns an object containing extracted AST elements, tokens, and errors.
+        Returns an object containing extracted Ast elements, tokens, and errors.
 
         .LINK
         https://psmodule.io/Ast/Functions/Core/Get-AstCommand/
@@ -80,7 +80,7 @@
         )]
         [string] $Script,
 
-        # An existing AST object to search.
+        # An existing Ast object to search.
         [Parameter(
             Mandatory,
             ValueFromPipeline,

--- a/src/functions/public/Core/Get-ASTFunction.ps1
+++ b/src/functions/public/Core/Get-ASTFunction.ps1
@@ -1,11 +1,11 @@
 ﻿function Get-AstFunction {
     <#
         .SYNOPSIS
-        Retrieves function definitions from a PowerShell script or AST.
+        Retrieves function definitions from a PowerShell script or Ast.
 
         .DESCRIPTION
         This function extracts function definitions from a given PowerShell script file, script content,
-        or an existing AST (Abstract Syntax Tree) object. It supports searching by function name
+        or an existing Ast (Abstract Syntax Tree) object. It supports searching by function name
         and can optionally search within nested functions and script block expressions.
 
         .EXAMPLE
@@ -43,13 +43,13 @@
         Errors : {}
         ```
 
-        Extracts function definitions from an existing AST object.
+        Extracts function definitions from an existing Ast object.
 
         .OUTPUTS
         PSCustomObject
 
         .NOTES
-        Contains AST objects, tokenized script content, and parsing errors if any.
+        Contains Ast objects, tokenized script content, and parsing errors if any.
 
         .LINK
         https://psmodule.io/Ast/Functions/Core/Get-AstFunction
@@ -79,7 +79,7 @@
         )]
         [string] $Script,
 
-        # An existing AST object to search.
+        # An existing Ast object to search.
         [Parameter(
             Mandatory,
             ValueFromPipeline,

--- a/src/functions/public/Core/Get-ASTScript.ps1
+++ b/src/functions/public/Core/Get-ASTScript.ps1
@@ -1,10 +1,10 @@
 ﻿function Get-AstScript {
     <#
         .SYNOPSIS
-        Parses a PowerShell script or script file and returns its abstract syntax tree (AST).
+        Parses a PowerShell script or script file and returns its abstract syntax tree (Ast).
 
         .DESCRIPTION
-        The Get-AstScript function parses a PowerShell script or script file and returns its abstract syntax tree (AST),
+        The Get-AstScript function parses a PowerShell script or script file and returns its abstract syntax tree (Ast),
         along with tokens and errors encountered during parsing. This function can be used to analyze the structure
         of a script by specifying either the script content directly or the path to a script file.
 
@@ -18,7 +18,7 @@
         Errors : {Error1, Error2, ...}
         ```
 
-        Parses the PowerShell script located at "C:\\Scripts\\example.ps1" and returns its AST, tokens, and any parsing errors.
+        Parses the PowerShell script located at "C:\\Scripts\\example.ps1" and returns its Ast, tokens, and any parsing errors.
 
         .EXAMPLE
         Get-AstScript -Script "Write-Host 'Hello World'"
@@ -30,14 +30,14 @@
         Errors : {}
         ```
 
-        Parses the provided PowerShell script string and returns its AST, tokens, and any parsing errors.
+        Parses the provided PowerShell script string and returns its Ast, tokens, and any parsing errors.
 
         .OUTPUTS
         PSCustomObject
 
         .NOTES
         The returned custom object contains the following properties:
-        - `Ast` - [System.Management.Automation.Language.ScriptBlockAst]. The abstract syntax tree (AST) of the parsed script.
+        - `Ast` - [System.Management.Automation.Language.ScriptBlockAst]. The abstract syntax tree (Ast) of the parsed script.
         - `Tokens` - [System.Management.Automation.Language.Token[]]. The tokens generated during parsing.
         - `Errors` - [System.Management.Automation.Language.ParseError[]]. Any parsing errors encountered.
 

--- a/src/functions/public/Functions/Get-ASTFunctionAlias.ps1
+++ b/src/functions/public/Functions/Get-ASTFunctionAlias.ps1
@@ -1,4 +1,4 @@
-﻿function Get-ASTFunctionAlias {
+﻿function Get-AstFunctionAlias {
     <#
         .SYNOPSIS
         Retrieves function aliases from a PowerShell script or file.
@@ -10,7 +10,7 @@
         within nested functions and script blocks.
 
         .EXAMPLE
-        Get-ASTFunctionAlias -Path "C:\Scripts\MyScript.ps1" -Name "Get-User"
+        Get-AstFunctionAlias -Path "C:\Scripts\MyScript.ps1" -Name "Get-User"
 
         Output:
         ```powershell
@@ -22,7 +22,7 @@
         Retrieves aliases assigned to the function `Get-User` within the specified script file.
 
         .EXAMPLE
-        Get-ASTFunctionAlias -Script $scriptContent -Recurse
+        Get-AstFunctionAlias -Script $scriptContent -Recurse
 
         Output:
         ```powershell
@@ -40,7 +40,7 @@
         An object containing the function name and its associated aliases.
 
         .LINK
-        https://psmodule.io/AST/Functions/Functions/Get-ASTFunctionAlias
+        https://psmodule.io/Ast/Functions/Functions/Get-AstFunctionAlias
     #>
     [CmdletBinding()]
     param (
@@ -78,15 +78,15 @@
     process {
         switch ($PSCmdlet.ParameterSetName) {
             'Path' {
-                $functionAST = Get-ASTFunction -Name $Name -Path $Path -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Path $Path -Recurse:$Recurse
             }
             'Script' {
-                $functionAST = Get-ASTFunction -Name $Name -Script $Script -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Script $Script -Recurse:$Recurse
             }
         }
 
         # Process each function and extract aliases
-        $functionAST.Ast | ForEach-Object {
+        $functionAst.Ast | ForEach-Object {
             $funcName = $_.Name
             $funcAttributes = $_.Body.FindAll({ $args[0] -is [System.Management.Automation.Language.AttributeAst] }, $true) | Where-Object {
                 $_.Parent -is [System.Management.Automation.Language.ParamBlockAst]

--- a/src/functions/public/Functions/Get-ASTFunctionName.ps1
+++ b/src/functions/public/Functions/Get-ASTFunctionName.ps1
@@ -1,15 +1,15 @@
-﻿function Get-ASTFunctionName {
+﻿function Get-AstFunctionName {
     <#
         .SYNOPSIS
-        Retrieves the names of functions from an abstract syntax tree (AST) in a PowerShell script.
+        Retrieves the names of functions from an abstract syntax tree (Ast) in a PowerShell script.
 
         .DESCRIPTION
-        Parses a PowerShell script file or script content to extract function names using an abstract syntax tree (AST).
+        Parses a PowerShell script file or script content to extract function names using an abstract syntax tree (Ast).
         The function supports searching by name, parsing from a file path, or directly from a script string. It can also
         search within nested functions and script block expressions when the -Recurse switch is used.
 
         .EXAMPLE
-        Get-ASTFunctionName -Path "C:\Scripts\example.ps1"
+        Get-AstFunctionName -Path "C:\Scripts\example.ps1"
 
         Output:
         ```powershell
@@ -20,7 +20,7 @@
         Extracts function names from the specified PowerShell script file.
 
         .EXAMPLE
-        Get-ASTFunctionName -Script "function Test-Function { param($x) Write-Host $x }"
+        Get-AstFunctionName -Script "function Test-Function { param($x) Write-Host $x }"
 
         Output:
         ```powershell
@@ -30,7 +30,7 @@
         Extracts function names from the given script string.
 
         .EXAMPLE
-        Get-ASTFunctionName -Path "C:\Scripts\example.ps1" -Recurse
+        Get-AstFunctionName -Path "C:\Scripts\example.ps1" -Recurse
 
         Output:
         ```powershell
@@ -48,7 +48,7 @@
         The name of each function found in the PowerShell script.
 
         .LINK
-        https://psmodule.io/AST/Functions/Functions/Get-ASTFunctionName/
+        https://psmodule.io/Ast/Functions/Functions/Get-AstFunctionName/
     #>
 
     [CmdletBinding()]
@@ -87,15 +87,15 @@
     process {
         switch ($PSCmdlet.ParameterSetName) {
             'Path' {
-                $functionAST = Get-ASTFunction -Name $Name -Path $Path -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Path $Path -Recurse:$Recurse
             }
             'Script' {
-                $functionAST = Get-ASTFunction -Name $Name -Script $Script -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Script $Script -Recurse:$Recurse
             }
         }
 
         # Process each function and extract the name
-        $functionAST.Ast | ForEach-Object {
+        $functionAst.Ast | ForEach-Object {
             $_.Name
         }
     }

--- a/src/functions/public/Functions/Get-ASTFunctionType.ps1
+++ b/src/functions/public/Functions/Get-ASTFunctionType.ps1
@@ -1,7 +1,7 @@
-﻿function Get-ASTFunctionType {
+﻿function Get-AstFunctionType {
     <#
         .SYNOPSIS
-        Retrieves the type of an abstract syntax tree (AST) function.
+        Retrieves the type of an abstract syntax tree (Ast) function.
 
         .DESCRIPTION
         Parses a PowerShell script file or script content to determine the type of function present.
@@ -9,7 +9,7 @@
         It supports searching for specific function names and can process nested functions if required.
 
         .EXAMPLE
-        Get-ASTFunctionType -Path "C:\Scripts\MyScript.ps1"
+        Get-AstFunctionType -Path "C:\Scripts\MyScript.ps1"
 
         Output:
         ```powershell
@@ -22,7 +22,7 @@
         Parses the specified script file and identifies function types.
 
         .EXAMPLE
-        Get-ASTFunctionType -Script "function Test { param() Write-Output 'Hello' }"
+        Get-AstFunctionType -Script "function Test { param() Write-Output 'Hello' }"
 
         Output:
         ```powershell
@@ -40,7 +40,7 @@
         Represents the function name and its determined type.
 
         .LINK
-        https://psmodule.io/AST/Functions/Functions/Get-ASTFunctionType/
+        https://psmodule.io/Ast/Functions/Functions/Get-AstFunctionType/
     #>
     [OutputType([pscustomobject])]
     [CmdletBinding()]
@@ -79,14 +79,14 @@
     process {
         switch ($PSCmdlet.ParameterSetName) {
             'Path' {
-                $functionAST = Get-ASTFunction -Name $Name -Path $Path -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Path $Path -Recurse:$Recurse
             }
             'Script' {
-                $functionAST = Get-ASTFunction -Name $Name -Script $Script -Recurse:$Recurse
+                $functionAst = Get-AstFunction -Name $Name -Script $Script -Recurse:$Recurse
             }
         }
 
-        $functionAST.Ast | ForEach-Object {
+        $functionAst.Ast | ForEach-Object {
             $type = if ($_.IsWorkflow) {
                 'Workflow'
             } elseif ($_.IsConfiguration) {

--- a/src/functions/public/Lines/Get-ASTLineComment.ps1
+++ b/src/functions/public/Lines/Get-ASTLineComment.ps1
@@ -1,4 +1,4 @@
-﻿filter Get-ASTLineComment {
+﻿filter Get-AstLineComment {
     <#
         .SYNOPSIS
         Extracts comment tokens from a given line of PowerShell code.
@@ -9,7 +9,7 @@
         the specified kind, defaulting to 'Comment'.
 
         .EXAMPLE
-        "# This is a comment" | Get-ASTLineComment
+        "# This is a comment" | Get-AstLineComment
 
         Output:
         ```powershell
@@ -26,7 +26,7 @@
         An array of tokens representing comments extracted from the input line.
 
         .LINK
-        https://psmodule.io/AST/Functions/Lines/Get-ASTLineComment/
+        https://psmodule.io/Ast/Functions/Lines/Get-AstLineComment/
     #>
     [OutputType([System.Management.Automation.Language.Token[]])]
     [CmdletBinding()]

--- a/src/functions/public/Scripts/Get-ASTScriptCommand.ps1
+++ b/src/functions/public/Scripts/Get-ASTScriptCommand.ps1
@@ -1,4 +1,4 @@
-﻿function Get-ASTScriptCommand {
+﻿function Get-AstScriptCommand {
     <#
         .SYNOPSIS
         Retrieves the commands used within a specified PowerShell script.
@@ -9,17 +9,17 @@
         Returns details such as command name, position, and file reference.
 
         .EXAMPLE
-        Get-ASTScriptCommand -Path "C:\Scripts\example.ps1"
+        Get-AstScriptCommand -Path "C:\Scripts\example.ps1"
 
         Extracts and lists all commands found in the specified PowerShell script.
 
         .EXAMPLE
-        Get-ASTScriptCommand -Path "C:\Scripts\example.ps1" -IncludeCallOperators
+        Get-AstScriptCommand -Path "C:\Scripts\example.ps1" -IncludeCallOperators
 
         Extracts all commands, including those executed with call operators (& and .).
 
         .LINK
-        https://psmodule.io/AST/Functions/Scripts/Get-ASTScriptCommand/
+        https://psmodule.io/Ast/Functions/Scripts/Get-AstScriptCommand/
     #>
     [CmdletBinding(DefaultParameterSetName = 'Ast')]
     param (
@@ -46,7 +46,7 @@
         )]
         [string] $Script,
 
-        # An existing AST object to search.
+        # An existing Ast object to search.
         [Parameter(
             Mandatory,
             ValueFromPipeline,
@@ -81,13 +81,13 @@
         }
 
         # Gather CommandAsts
-        $commandAST = $scriptAst.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $Recurse)
+        $commandAst = $scriptAst.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $Recurse)
 
         if (-not $IncludeCallOperators) {
-            $commandAST = $commandAST | Where-Object { $_.InvocationOperator -notin 'Ampersand', 'Dot' }
+            $commandAst = $commandAst | Where-Object { $_.InvocationOperator -notin 'Ampersand', 'Dot' }
         }
 
-        $commandAST | ForEach-Object {
+        $commandAst | ForEach-Object {
             $invocationOperator = switch ($_.InvocationOperator) {
                 'Ampersand' { '&' }
                 'Dot' { '.' }


### PR DESCRIPTION
## Description

This pull request includes changes to multiple PowerShell functions to standardize the capitalization of "AST" to "Ast" and to rename several functions for consistency. The most important changes are as follows:

### Standardization of "AST" to "Ast":

* [`src/functions/public/Core/Get-ASTCommand.ps1`](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL4-R9): Changed all instances of "AST" to "Ast" in the function documentation and parameter descriptions. [[1]](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL4-R9) [[2]](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL22-R22) [[3]](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL34-R34) [[4]](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL47-R53) [[5]](diffhunk://#diff-c418410cd6d3505ed477b3cd920729a9ee2eb06e2ebaf9801f7d18042134531eL83-R83)
* [`src/functions/public/Core/Get-ASTFunction.ps1`](diffhunk://#diff-12c0e9214da31ea8123c85ed3408e69da86bc14630c6153967d9fe203f903d23L4-R8): Updated "AST" to "Ast" in the function documentation and parameter descriptions. [[1]](diffhunk://#diff-12c0e9214da31ea8123c85ed3408e69da86bc14630c6153967d9fe203f903d23L4-R8) [[2]](diffhunk://#diff-12c0e9214da31ea8123c85ed3408e69da86bc14630c6153967d9fe203f903d23L46-R52) [[3]](diffhunk://#diff-12c0e9214da31ea8123c85ed3408e69da86bc14630c6153967d9fe203f903d23L82-R82)
* [`src/functions/public/Core/Get-ASTScript.ps1`](diffhunk://#diff-066935b5ba09d1a7e26efc9c07f4fa89f59179d42965af3b1b0b88ce2baf3024L4-R7): Modified "AST" to "Ast" in the function documentation and parameter descriptions. [[1]](diffhunk://#diff-066935b5ba09d1a7e26efc9c07f4fa89f59179d42965af3b1b0b88ce2baf3024L4-R7) [[2]](diffhunk://#diff-066935b5ba09d1a7e26efc9c07f4fa89f59179d42965af3b1b0b88ce2baf3024L21-R21) [[3]](diffhunk://#diff-066935b5ba09d1a7e26efc9c07f4fa89f59179d42965af3b1b0b88ce2baf3024L33-R40)

### Function Renaming for Consistency:

* [`src/functions/public/Functions/Get-ASTFunctionAlias.ps1`](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L1-R1): Renamed the function from `Get-ASTFunctionAlias` to `Get-AstFunctionAlias` and updated all references accordingly. [[1]](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L1-R1) [[2]](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L13-R13) [[3]](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L25-R25) [[4]](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L43-R43) [[5]](diffhunk://#diff-1df2456a77c20bca12ec99f422e6965edae54128f290dcc749be6036c6823be0L81-R89)
* [`src/functions/public/Functions/Get-ASTFunctionName.ps1`](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L1-R12): Renamed the function from `Get-ASTFunctionName` to `Get-AstFunctionName` and updated all references accordingly. [[1]](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L1-R12) [[2]](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L23-R23) [[3]](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L33-R33) [[4]](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L51-R51) [[5]](diffhunk://#diff-4653cd432446aa25615ea39c8651d548676676a14800c88eb0b438b939674170L90-R98)
* [`src/functions/public/Functions/Get-ASTFunctionType.ps1`](diffhunk://#diff-6f1880148021050f019b08d8e8c20da44a4e8402258091263d4893dee7ef9a7aL1-R12): Renamed the function from `Get-ASTFunctionType` to `Get-AstFunctionType` and updated all references accordingly. [[1]](diffhunk://#diff-6f1880148021050f019b08d8e8c20da44a4e8402258091263d4893dee7ef9a7aL1-R12) [[2]](diffhunk://#diff-6f1880148021050f019b08d8e8c20da44a4e8402258091263d4893dee7ef9a7aL25-R25) [[3]](diffhunk://#diff-6f1880148021050f019b08d8e8c20da44a4e8402258091263d4893dee7ef9a7aL43-R43) [[4]](diffhunk://#diff-6f1880148021050f019b08d8e8c20da44a4e8402258091263d4893dee7ef9a7aL82-R89)
* [`src/functions/public/Lines/Get-ASTLineComment.ps1`](diffhunk://#diff-7ef05603786634e7546e1c5d47e915c2067024af002b4d0532eed1ab6c010bc1L1-R1): Renamed the filter from `Get-ASTLineComment` to `Get-AstLineComment` and updated all references accordingly. [[1]](diffhunk://#diff-7ef05603786634e7546e1c5d47e915c2067024af002b4d0532eed1ab6c010bc1L1-R1) [[2]](diffhunk://#diff-7ef05603786634e7546e1c5d47e915c2067024af002b4d0532eed1ab6c010bc1L12-R12) [[3]](diffhunk://#diff-7ef05603786634e7546e1c5d47e915c2067024af002b4d0532eed1ab6c010bc1L29-R29)
* [`src/functions/public/Scripts/Get-ASTScriptCommand.ps1`](diffhunk://#diff-9207269684f85ef8ff0eae5ea46c0eedac65cd4891d0a01c21852fdecfadc9bbL1-R1): Renamed the function from `Get-ASTScriptCommand` to `Get-AstScriptCommand` and updated all references accordingly. [[1]](diffhunk://#diff-9207269684f85ef8ff0eae5ea46c0eedac65cd4891d0a01c21852fdecfadc9bbL1-R1) [[2]](diffhunk://#diff-9207269684f85ef8ff0eae5ea46c0eedac65cd4891d0a01c21852fdecfadc9bbL12-R22)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
