### PR TITLE
[Fix]: Change ternary operator to if/else for Desktop compatibility (#24)

### DIFF
--- a/src/functions/public/Scripts/Get-AstScriptCommand.ps1
+++ b/src/functions/public/Scripts/Get-AstScriptCommand.ps1
@@ -94,7 +94,7 @@
             }
             $_.CommandElements[0].Extent | Where-Object { $_.Text -like $Name } | ForEach-Object {
                 [pscustomobject]@{
-                    Name              = [string]::IsNullOrEmpty($invocationOperator) ? $_.Text : $invocationOperator
+                    Name              = if ([string]::IsNullOrEmpty($invocationOperator)) { $_.Text } else { $invocationOperator }
                     StartLineNumber   = $_.StartLineNumber
                     StartColumnNumber = $_.StartColumnNumber
                     EndLineNumber     = $_.EndLineNumber


### PR DESCRIPTION
Fixes #24

## Description

So long as the module is compatible with the PowerShell Desktop edition, ternary statements can't be used. Changed one in `Get-AstScriptCommand` to an if/else.

## Type of change

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
