### PR TITLE
🩹 [Patch]: Add missing labels for Dependabot updates in configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,8 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request makes a small configuration update to the Dependabot settings, adding labels to pull requests that update GitHub Actions dependencies.

* Added `dependencies` and `github-actions` labels to Dependabot PRs for GitHub Actions updates in `.github/dependabot.yml`.
