### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,27 @@
 # Ast
 
-A PowerShell module for using the Abstract Syntax Tree (AST) on any PowerShell code.
-
-## Prerequisites
-
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule) for building, testing and publishing the module.
+Ast is a PowerShell module for using the PowerShell abstract syntax tree to analyze PowerShell code.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name Ast
 Import-Module -Name Ast
 ```
 
-## Usage
+## Documentation
 
-Here is a list of example that are typical use cases for the module.
+Documentation is published at [psmodule.io/Ast](https://psmodule.io/Ast/).
 
-### Example 1: Get the function name from a script
-
-This example shows how to get the function name from a script.
+Use PowerShell help and command discovery for module details:
 
 ```powershell
-Get-AstFunctionName -Path 'Test-Me.ps1'
-Test-Me
+Get-Command -Module Ast
+Get-Help <CommandName> -Examples
 ```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Tools
-
-- [lzybkr/ShowPSAst](https://github.com/lzybkr/ShowPSAst)
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ast
 
-Ast is a PowerShell module for using the PowerShell abstract syntax tree to analyze PowerShell code.
+Ast is a PowerShell module for using the PowerShell abstract syntax tree (AST) to analyze PowerShell code. It provides
+commands to extract functions, commands, aliases, comments, and script structure from a file, a string of script content,
+or an existing AST object.
 
 ## Installation
 
@@ -11,6 +13,31 @@ Install-PSResource -Name Ast
 Import-Module -Name Ast
 ```
 
+## Usage
+
+The commands accept a file path (`-Path`), inline script content (`-Script`), or an existing AST object (`-Ast`), and
+default to matching everything so you can narrow the results with `-Name`.
+
+### Example: List the functions defined in a script
+
+```powershell
+Get-AstFunction -Path ./MyScript.ps1
+Get-AstFunctionName -Path ./MyScript.ps1
+```
+
+### Example: Find the commands invoked by a script
+
+```powershell
+Get-AstCommand -Path ./MyScript.ps1
+Get-AstCommand -Script "Get-Process; Write-Host 'Hello'"
+```
+
+### Example: Inspect a single function by name
+
+```powershell
+Get-AstFunction -Path ./MyScript.ps1 -Name 'Test-Me'
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/Ast](https://psmodule.io/Ast/).
@@ -19,9 +46,9 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Ast
-Get-Help <CommandName> -Examples
+Get-Help -Name Get-AstFunction -Examples
 ```
 
-## Contributing
+## Related tools
 
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.
+- [lzybkr/ShowPSAst](https://github.com/lzybkr/ShowPSAst) — an interactive viewer for exploring the PowerShell AST.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Import-Module -Name Ast
 
 ## Usage
 
-The commands accept a file path (`-Path`), inline script content (`-Script`), or an existing AST object (`-Ast`), and
-default to matching everything so you can narrow the results with `-Name`.
+The commands accept a file path (`-Path`) or inline script content (`-Script`), and default to matching everything so
+you can narrow the results with `-Name`.
 
 ### Example: List the functions defined in a script
 


### PR DESCRIPTION
The README now works as a concise landing page for the module. It leads with what the module does, how to install it, a short usage showcase built from real commands, and where to find the full generated documentation.

## What changed

- **Overview** — a one-paragraph description of what `Ast` does.
- **Installation** — uses `Install-PSResource`, the current PowerShell Gallery client.
- **Usage** — a short showcase of the most common commands (`Get-AstFunction`, `Get-AstFunctionName`, `Get-AstCommand`) run against a script. This is a getting-started showcase, not a full command reference: exhaustive per-command details stay in PowerShell help and the generated documentation so the landing page does not duplicate them.
- **Documentation** — links to [psmodule.io/Ast](https://psmodule.io/Ast/) and shows `Get-Command` / `Get-Help` discovery using a real command name.
- **Related tools** — keeps the pointer to the external `ShowPSAst` AST viewer.
- Removed the `## Contributing` section.

## Technical details

- Updates `README.md` only.
- Aligns this repository with the standard module landing-page format used across PSModule.
